### PR TITLE
Change Request struct to take references to underlying data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ fn duplicate_request(r: &request::Request) -> bool {
   } else {
     // Versions that don't use the Dependency API make one request, either for
     // specs or for versions. We want to count each of those.
-    !METADATA_PATHS.contains(&r.request_path)
+    !METADATA_PATHS.contains(&r.request_path.as_ref())
   }
 }
 
@@ -84,7 +84,7 @@ pub fn print_unknown_user_agents(path: &str, opts: &Options) {
   file::reader(&path, &opts).lines().for_each(|line| {
     let l = &line.unwrap();
     let r: request::Request = serde_json::from_str(l).unwrap();
-    match user_agent::parse(r.user_agent) {
+    match user_agent::parse(r.user_agent.as_ref()) {
       None => println!("{}", r.user_agent),
       Some(_) => (),
     }
@@ -101,10 +101,10 @@ pub fn count_line(times: &mut TimeMap, line: String) {
   let date = r.timestamp.get(..10).unwrap().to_string();
   let counters = times.entry(date).or_insert(HashMap::new());
 
-  increment(counters, "tls_cipher", r.tls_cipher);
-  increment(counters, "server_region", r.server_region);
+  increment(counters, "tls_cipher", r.tls_cipher.as_ref());
+  increment(counters, "server_region", r.server_region.as_ref());
 
-  if let Some(ua) = user_agent::parse(r.user_agent) {
+  if let Some(ua) = user_agent::parse(r.user_agent.as_ref()) {
     increment(counters, "rubygems", ua.rubygems);
     increment_maybe(counters, "bundler", ua.bundler);
     increment_maybe(counters, "ruby", ua.ruby);

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
+
 #[derive(Deserialize, Debug)]
 pub struct Request<'a> {
-  pub timestamp: &'a str,
+  pub timestamp: Cow<'a, str>,
   // time_elapsed: u8,
   // client_ip: String,
   // client_continent: String,
@@ -13,14 +15,14 @@ pub struct Request<'a> {
   // client_connection: String,
   // request: String,
   // request_host: String,
-  pub request_path: &'a str,
-  pub request_query: &'a str,
+  pub request_path: Cow<'a, str>,
+  pub request_query: Cow<'a, str>,
   // request_bytes: u16,
-  pub user_agent: &'a str,
+  pub user_agent: Cow<'a, str>,
   pub http2: bool,
   // pub tls: Option<bool>,
-  pub tls_version: &'a str,
-  pub tls_cipher: &'a str,
+  pub tls_version: Cow<'a, str>,
+  pub tls_cipher: Cow<'a, str>,
   // response_status: String,
   // response_text: String,
   // response_bytes: u16,
@@ -28,6 +30,6 @@ pub struct Request<'a> {
   // cache_state: String,
   // cache_lastuse: f32,
   // cache_hits: u16,
-  pub server_region: &'a str,
+  pub server_region: Cow<'a, str>,
   // server_datacenter: String,
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,6 @@
 #[derive(Deserialize, Debug)]
-pub struct Request {
-  pub timestamp: String,
+pub struct Request<'a> {
+  pub timestamp: &'a str,
   // time_elapsed: u8,
   // client_ip: String,
   // client_continent: String,
@@ -13,14 +13,14 @@ pub struct Request {
   // client_connection: String,
   // request: String,
   // request_host: String,
-  pub request_path: String,
-  pub request_query: String,
+  pub request_path: &'a str,
+  pub request_query: &'a str,
   // request_bytes: u16,
-  pub user_agent: String,
+  pub user_agent: &'a str,
   pub http2: bool,
   // pub tls: Option<bool>,
-  pub tls_version: String,
-  pub tls_cipher: String,
+  pub tls_version: &'a str,
+  pub tls_cipher: &'a str,
   // response_status: String,
   // response_text: String,
   // response_bytes: u16,
@@ -28,6 +28,6 @@ pub struct Request {
   // cache_state: String,
   // cache_lastuse: f32,
   // cache_hits: u16,
-  pub server_region: String,
+  pub server_region: &'a str,
   // server_datacenter: String,
 }


### PR DESCRIPTION
Fix #1 

This PR changes `Request` to take references to the underlying data, which should result in less allocation during parsing. Hard to gauge the effect without a large file to test on.

I also made the meta data paths a const array as part of this change, which removes the need to allocate a Vec for them (and use lazy_static).