### PR TITLE
Fix test.

### DIFF
--- a/src/user_agent.rs
+++ b/src/user_agent.rs
@@ -118,6 +118,8 @@ pub fn parse(a: &str) -> Option<UserAgent> {
 
 #[cfg(test)]
 mod tests {
+  extern crate test;
+
   use super::*;
   use crate::file;
   use std::io::BufRead;


### PR DESCRIPTION
`extern crate test` is needed to use Bencher in Rust 2018

More info: https://www.reddit.com/r/rust/comments/auolx4/why_do_i_need_extern_crate_test_to_use_bencher_in/

```
$ cargo +nightly test
...
   Compiling kirby v0.1.0 (/home/rubenrua/tmp/uned-p-insights/src/kirby)
error[E0432]: unresolved import `test`
   --> src/user_agent.rs:124:7
    |
124 |   use test::Bencher;
    |       ^^^^ use of undeclared type or module `test`

warning: static variable `br` should have an upper case name
  --> src/user_agent.rs:21:16
   |
21 |     static ref br: Regex = Regex::new(r"\Abundler/([0-9a-zA-Z.\-]+) rubygems/([0-9a-zA-Z.\-]+) ruby/([0-9a-zA-Z.\-]+) \(([^)]*)\) command/(.*?)(?: jruby/([0-9a-zA-Z.\-]+))?(?: truffleruby/([0-9a-zA-Z.\-]+))?(?: options/(.*?))?(?: ci/(.*?))? [a-f0-9]{16}(?: Gemstash/([0-9a-zA-Z.\-]+))?\z").unwrap();
   |                ^^ help: convert the identifier to upper case: `BR`
   |
   = note: #[warn(non_upper_case_globals)] on by default

warning: static variable `rr` should have an upper case name
  --> src/user_agent.rs:22:16
   |
22 |     static ref rr: Regex = Regex::new(r"\A(?:Ruby, )?RubyGems/([0-9a-z.\-]+) (.*) Ruby/([0-9a-z.\-]+) \(.*?\)(?: jruby| truffleruby| rbx)?(?: Gemstash/([0-9a-z.\-]+))?\z").unwrap();
   |                ^^ help: convert the identifier to upper case: `RR`

warning: static variable `gr` should have an upper case name
  --> src/user_agent.rs:23:16
   |
23 |     static ref gr: Regex = Regex::new(r"\ARuby, Gems ([0-9a-z.\-]+)\z").unwrap();
   |                ^^ help: convert the identifier to upper case: `GR`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `kirby`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```
