### PR TITLE
Run `cargo fmt`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Running `cargo fmt`
+123456de67aee5b358f338cbef829e08f81ea9d7

--- a/src/bin/kirby-s3.rs
+++ b/src/bin/kirby-s3.rs
@@ -5,100 +5,100 @@ extern crate serde_json;
 
 extern crate kirby;
 
-use aws_lambda as lambda;
 use crate::lambda::event::s3::S3Event;
+use aws_lambda as lambda;
 use flate2::read::GzDecoder;
+use percent_encoding::percent_decode;
 use rusoto_core::region::Region;
 use rusoto_s3::*;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::io::Cursor;
 use std::io::Read;
-use percent_encoding::percent_decode;
 
 use kirby::Options;
 use kirby::stream_stats;
 
 fn read_object(bucket_name: &str, key: &str) -> Box<dyn BufRead> {
-  let get_req = GetObjectRequest {
-    bucket: bucket_name.to_owned(),
-    key: key.to_owned(),
-    ..Default::default()
-  };
+    let get_req = GetObjectRequest {
+        bucket: bucket_name.to_owned(),
+        key: key.to_owned(),
+        ..Default::default()
+    };
 
-  let client = S3Client::new(Region::UsWest2);
-  let result = client
-    .get_object(get_req)
-    .sync()
-    .expect("Couldn't GET object");
+    let client = S3Client::new(Region::UsWest2);
+    let result = client
+        .get_object(get_req)
+        .sync()
+        .expect("Couldn't GET object");
 
-  let mut bytes = Vec::new();
-  result
-    .body
-    .unwrap()
-    .into_blocking_read()
-    .read_to_end(&mut bytes)
-    .expect("Couldn't read object body stream");
+    let mut bytes = Vec::new();
+    result
+        .body
+        .unwrap()
+        .into_blocking_read()
+        .read_to_end(&mut bytes)
+        .expect("Couldn't read object body stream");
 
-  if key.ends_with("gz") {
-    Box::new(BufReader::new(GzDecoder::new(Cursor::new(bytes))))
-  } else {
-    Box::new(BufReader::new(Cursor::new(bytes)))
-  }
+    if key.ends_with("gz") {
+        Box::new(BufReader::new(GzDecoder::new(Cursor::new(bytes))))
+    } else {
+        Box::new(BufReader::new(Cursor::new(bytes)))
+    }
 }
 
 fn write_object(bucket_name: &str, key: &str, body: &str) -> rusoto_s3::PutObjectOutput {
-  let req = PutObjectRequest {
-    bucket: bucket_name.to_owned(),
-    key: key.to_owned(),
-    body: Some(StreamingBody::from(body.as_bytes().to_vec())),
-    ..Default::default()
-  };
+    let req = PutObjectRequest {
+        bucket: bucket_name.to_owned(),
+        key: key.to_owned(),
+        body: Some(StreamingBody::from(body.as_bytes().to_vec())),
+        ..Default::default()
+    };
 
-  let client = S3Client::new(Region::UsWest2);
-  client.put_object(req).sync().expect("Couldn't PUT object")
+    let client = S3Client::new(Region::UsWest2);
+    client.put_object(req).sync().expect("Couldn't PUT object")
 }
 
 fn main() {
-  lambda::logger::init();
+    lambda::logger::init();
 
-  lambda::start(|input: S3Event| {
-    let opts = Options {
-      paths: vec![],
-      verbose: false,
-      unknown: false,
-    };
+    lambda::start(|input: S3Event| {
+        let opts = Options {
+            paths: vec![],
+            verbose: false,
+            unknown: false,
+        };
 
-    for record in input.records {
-      if let Some(bucket_name) = record.s3.bucket.name {
-        if let Some(url_key) = record.s3.object.key {
-          let key = percent_decode(url_key.as_bytes()).decode_utf8()?;
-          info!(
-            "{} downloading {}/{}",
-            time::now_utc().rfc3339(),
-            &bucket_name,
-            &key
-          );
-          let reader = read_object(&bucket_name, &key);
+        for record in input.records {
+            if let Some(bucket_name) = record.s3.bucket.name {
+                if let Some(url_key) = record.s3.object.key {
+                    let key = percent_decode(url_key.as_bytes()).decode_utf8()?;
+                    info!(
+                        "{} downloading {}/{}",
+                        time::now_utc().rfc3339(),
+                        &bucket_name,
+                        &key
+                    );
+                    let reader = read_object(&bucket_name, &key);
 
-          info!("{} calculating stats...", time::now_utc().rfc3339());
-          let content = stream_stats(reader, &opts);
+                    info!("{} calculating stats...", time::now_utc().rfc3339());
+                    let content = stream_stats(reader, &opts);
 
-          let result_key = [&key, ".json"]
-            .concat()
-            .replace("fastly_json", "fastly_stats");
-          info!(
-            "{} uploading results to {}",
-            time::now_utc().rfc3339(),
-            &result_key
-          );
-          write_object(&bucket_name, &result_key, &json!(content).to_string());
+                    let result_key = [&key, ".json"]
+                        .concat()
+                        .replace("fastly_json", "fastly_stats");
+                    info!(
+                        "{} uploading results to {}",
+                        time::now_utc().rfc3339(),
+                        &result_key
+                    );
+                    write_object(&bucket_name, &result_key, &json!(content).to_string());
 
-          info!("{} done with {}", time::now_utc().rfc3339(), &key);
+                    info!("{} done with {}", time::now_utc().rfc3339(), &key);
+                }
+            }
         }
-      }
-    }
 
-    Ok("ok")
-  })
+        Ok("ok")
+    })
 }

--- a/src/bin/kirby.rs
+++ b/src/bin/kirby.rs
@@ -10,46 +10,48 @@ use kirby::Options;
 use rayon::prelude::*;
 
 fn main() {
-  let mut opts = Options {
-    paths: ["test/sample_10.log".to_string()].to_vec(),
-    unknown: false,
-    verbose: false,
-  };
+    let mut opts = Options {
+        paths: ["test/sample_10.log".to_string()].to_vec(),
+        unknown: false,
+        verbose: false,
+    };
 
-  {
-    let mut ap = ArgumentParser::new();
-    ap.set_description("Parse a RubyGems.org Fastly JSON log file.");
-    ap.refer(&mut opts.unknown).add_option(
-      &["-u", "--unknown"],
-      StoreTrue,
-      "Print only unrecognized user agent strings",
-    );
-    ap.refer(&mut opts.verbose)
-      .add_option(&["-v", "--verbose"], StoreTrue, "Be verbose");
-    ap.refer(&mut opts.paths)
-      .add_argument("FILE", Collect, "Paths to the log file(s) to process");
-    ap.parse_args_or_exit();
-  }
+    {
+        let mut ap = ArgumentParser::new();
+        ap.set_description("Parse a RubyGems.org Fastly JSON log file.");
+        ap.refer(&mut opts.unknown).add_option(
+            &["-u", "--unknown"],
+            StoreTrue,
+            "Print only unrecognized user agent strings",
+        );
+        ap.refer(&mut opts.verbose)
+            .add_option(&["-v", "--verbose"], StoreTrue, "Be verbose");
+        ap.refer(&mut opts.paths).add_argument(
+            "FILE",
+            Collect,
+            "Paths to the log file(s) to process",
+        );
+        ap.parse_args_or_exit();
+    }
 
-  if opts.unknown {
-    opts
-      .paths
-      .par_iter()
-      .for_each(|path| kirby::print_unknown_user_agents(path, &opts));
-    return;
-  }
+    if opts.unknown {
+        opts.paths
+            .par_iter()
+            .for_each(|path| kirby::print_unknown_user_agents(path, &opts));
+        return;
+    }
 
-  let stats = opts
-    .paths
-    .par_iter()
-    .map(|path| kirby::file_stats(path, &opts))
-    .reduce_with(|a, b| kirby::combine_stats(&a, &b))
-    .unwrap();
+    let stats = opts
+        .paths
+        .par_iter()
+        .map(|path| kirby::file_stats(path, &opts))
+        .reduce_with(|a, b| kirby::combine_stats(&a, &b))
+        .unwrap();
 
-  let output = json!({
-    "ran_at": format!("{}", time::now_utc().rfc3339()),
-    "stats": stats,
-    "files": opts.paths,
-  });
-  println!("{}", output);
+    let output = json!({
+      "ran_at": format!("{}", time::now_utc().rfc3339()),
+      "stats": stats,
+      "files": opts.paths,
+    });
+    println!("{}", output);
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -6,19 +6,19 @@ use std::io::BufReader;
 use std::path::Path;
 
 pub fn reader(filename: &str, opts: &super::Options) -> Box<dyn BufRead> {
-  if opts.verbose {
-    println!("Opening log file {}", filename);
-  }
+    if opts.verbose {
+        println!("Opening log file {}", filename);
+    }
 
-  let path = Path::new(filename);
-  let file = match File::open(path) {
-    Err(why) => panic!("couldn't open {}: {}", path.display(), why),
-    Ok(file) => file,
-  };
+    let path = Path::new(filename);
+    let file = match File::open(path) {
+        Err(why) => panic!("couldn't open {}: {}", path.display(), why),
+        Ok(file) => file,
+    };
 
-  if path.extension() == Some(OsStr::new("gz")) {
-    Box::new(BufReader::with_capacity(128 * 1024, GzDecoder::new(file)))
-  } else {
-    Box::new(BufReader::with_capacity(128 * 1024, file))
-  }
+    if path.extension() == Some(OsStr::new("gz")) {
+        Box::new(BufReader::with_capacity(128 * 1024, GzDecoder::new(file)))
+    } else {
+        Box::new(BufReader::with_capacity(128 * 1024, file))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,66 +9,66 @@ extern crate enum_map;
 use enum_map::EnumMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::net::IpAddr;
 use std::io::*;
+use std::net::IpAddr;
 
 mod file;
 mod request;
 mod user_agent;
 
 const METADATA_PATHS: [&str; 4] = [
-  "/latest_specs.4.8.gz",
-  "/prerelease_specs.4.8.gz",
-  "/specs.4.8.gz",
-  "/versions",
+    "/latest_specs.4.8.gz",
+    "/prerelease_specs.4.8.gz",
+    "/specs.4.8.gz",
+    "/versions",
 ];
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Enum, Serialize)]
 pub enum FieldName {
-  tls_cipher,
-  server_region,
-  rubygems,
-  bundler,
-  ruby,
-  platform,
-  ci,
-  gemstash,
+    tls_cipher,
+    server_region,
+    rubygems,
+    bundler,
+    ruby,
+    platform,
+    ci,
+    gemstash,
 }
 
 type UserIdentifier = IpAddr;
 
 #[derive(Default, Serialize)]
 pub struct ValueUniqueCounter {
-  total: usize,
-  unique: usize,
-  #[serde(skip_serializing)]
-  index: HashSet<UserIdentifier>,
+    total: usize,
+    unique: usize,
+    #[serde(skip_serializing)]
+    index: HashSet<UserIdentifier>,
 }
 
 impl ValueUniqueCounter {
-  fn increment(&mut self, key: UserIdentifier) {
-    self.total += 1;
-    if self.index.insert(key) {
-      self.unique += 1;
+    fn increment(&mut self, key: UserIdentifier) {
+        self.total += 1;
+        if self.index.insert(key) {
+            self.unique += 1;
+        }
     }
-  }
 
-  fn combine(&mut self, other: &ValueUniqueCounter) {
-    self.total += other.total;
-    self.index = &self.index | &other.index;
-    self.unique = self.index.len();
-  }
+    fn combine(&mut self, other: &ValueUniqueCounter) {
+        self.total += other.total;
+        self.index = &self.index | &other.index;
+        self.unique = self.index.len();
+    }
 }
 
 impl Clone for ValueUniqueCounter {
-  fn clone(&self) -> Self {
-    ValueUniqueCounter {
-      total: self.total,
-      unique: self.unique,
-      index: self.index.clone(),
+    fn clone(&self) -> Self {
+        ValueUniqueCounter {
+            total: self.total,
+            unique: self.unique,
+            index: self.index.clone(),
+        }
     }
-  }
 }
 
 type ValueMap = HashMap<String, ValueUniqueCounter>;
@@ -76,122 +76,134 @@ type NameMap = EnumMap<FieldName, ValueMap>;
 type TimeMap = HashMap<String, NameMap>;
 
 pub struct Options {
-  pub verbose: bool,
-  pub unknown: bool,
-  pub paths: Vec<String>,
+    pub verbose: bool,
+    pub unknown: bool,
+    pub paths: Vec<String>,
 }
 
 pub fn combine_stats(left: &TimeMap, right: &TimeMap) -> TimeMap {
-  let mut left_times = left.clone();
-  for (time, names) in right {
-    let left_names = left_times
-      .entry(time.to_string())
-      .or_insert(enum_map!{_ => HashMap::default()});
-    for (name, versions) in names {
-      let left_versions = &mut left_names[name];
-      for (version, counter) in versions {
-        let left_counter = left_versions.entry(version.to_string()).or_default();
-        left_counter.combine(counter);
-      }
+    let mut left_times = left.clone();
+    for (time, names) in right {
+        let left_names = left_times
+            .entry(time.to_string())
+            .or_insert(enum_map! {_ => HashMap::default()});
+        for (name, versions) in names {
+            let left_versions = &mut left_names[name];
+            for (version, counter) in versions {
+                let left_counter = left_versions.entry(version.to_string()).or_default();
+                left_counter.combine(counter);
+            }
+        }
     }
-  }
 
-  left_times
+    left_times
 }
 
 fn duplicate_request(r: &request::Request) -> bool {
-  if r.request_path == "/api/v1/dependencies" {
-    // Requests for dependencies are recursive, and so we want to count only one
-    // request per time a user runs a command, rather than every request that was
-    // made to satisfy that command. It seems like RubyGems makes one HEAD
-    // request with no query, and Bundler makes one GET request with no query,
-    // per command that is run. We ignore the rest for stats purposes.
-    !r.request_query.is_empty()
-  } else {
-    // Versions that don't use the Dependency API make one request, either for
-    // specs or for versions. We want to count each of those.
-    !METADATA_PATHS.contains(&r.request_path.as_ref())
-  }
+    if r.request_path == "/api/v1/dependencies" {
+        // Requests for dependencies are recursive, and so we want to count only one
+        // request per time a user runs a command, rather than every request that was
+        // made to satisfy that command. It seems like RubyGems makes one HEAD
+        // request with no query, and Bundler makes one GET request with no query,
+        // per command that is run. We ignore the rest for stats purposes.
+        !r.request_query.is_empty()
+    } else {
+        // Versions that don't use the Dependency API make one request, either for
+        // specs or for versions. We want to count each of those.
+        !METADATA_PATHS.contains(&r.request_path.as_ref())
+    }
 }
 
 fn increment(counters: &mut NameMap, name: FieldName, value: &str, key: UserIdentifier) {
-  let counter = counters[name].entry(String::from(value)).or_default();
-  counter.increment(key);
+    let counter = counters[name].entry(String::from(value)).or_default();
+    counter.increment(key);
 }
 
-fn increment_maybe(counters: &mut NameMap, name: FieldName, maybe_value: Option<&str>, key: UserIdentifier) {
-  if let Some(value) = maybe_value {
-    increment(counters, name, value, key);
-  }
+fn increment_maybe(
+    counters: &mut NameMap,
+    name: FieldName,
+    maybe_value: Option<&str>,
+    key: UserIdentifier,
+) {
+    if let Some(value) = maybe_value {
+        increment(counters, name, value, key);
+    }
 }
 
 pub fn print_unknown_user_agents(path: &str, opts: &Options) {
-  file::reader(path, opts).split(b'\n').for_each(|line| {
-    let l = &line.unwrap();
-    let r: request::Request = serde_json::from_slice(l).unwrap();
-    if user_agent::parse(r.user_agent.as_ref()).is_none() { println!("{}", r.user_agent) }
-  });
+    file::reader(path, opts).split(b'\n').for_each(|line| {
+        let l = &line.unwrap();
+        let r: request::Request = serde_json::from_slice(l).unwrap();
+        if user_agent::parse(r.user_agent.as_ref()).is_none() {
+            println!("{}", r.user_agent)
+        }
+    });
 }
 
 pub fn count_line(times: &mut TimeMap, line: String) {
-  let r: request::Request = serde_json::from_str(&line).unwrap();
+    let r: request::Request = serde_json::from_str(&line).unwrap();
 
-  if duplicate_request(&r) {
-    return;
-  }
+    if duplicate_request(&r) {
+        return;
+    }
 
-  let date = r.timestamp.get(..10).unwrap().to_string();
-  let counters = times
-    .entry(date)
-    .or_insert(enum_map!{_ => HashMap::default()});
+    let date = r.timestamp.get(..10).unwrap().to_string();
+    let counters = times
+        .entry(date)
+        .or_insert(enum_map! {_ => HashMap::default()});
 
-  let user_key = r.client_ip.parse().expect("ipaddr parse error");
+    let user_key = r.client_ip.parse().expect("ipaddr parse error");
 
-  increment(counters, FieldName::tls_cipher, r.tls_cipher.as_ref(), user_key);
-  if let Some(ua) = user_agent::parse(r.user_agent.as_ref()) {
-    increment(counters, FieldName::rubygems, ua.rubygems, user_key);
-    increment_maybe(counters, FieldName::bundler, ua.bundler, user_key);
-    increment_maybe(counters, FieldName::ruby, ua.ruby, user_key);
-    increment_maybe(counters, FieldName::platform, ua.platform, user_key);
-    increment_maybe(counters, FieldName::ci, ua.ci, user_key);
-    increment_maybe(counters, FieldName::gemstash, ua.gemstash, user_key);
-  }
+    increment(
+        counters,
+        FieldName::tls_cipher,
+        r.tls_cipher.as_ref(),
+        user_key,
+    );
+    if let Some(ua) = user_agent::parse(r.user_agent.as_ref()) {
+        increment(counters, FieldName::rubygems, ua.rubygems, user_key);
+        increment_maybe(counters, FieldName::bundler, ua.bundler, user_key);
+        increment_maybe(counters, FieldName::ruby, ua.ruby, user_key);
+        increment_maybe(counters, FieldName::platform, ua.platform, user_key);
+        increment_maybe(counters, FieldName::ci, ua.ci, user_key);
+        increment_maybe(counters, FieldName::gemstash, ua.gemstash, user_key);
+    }
 }
 
 pub fn stream_stats(stream: Box<dyn BufRead>, opts: &Options) -> TimeMap {
-  let mut times = TimeMap::default();
-  let mut lineno = 0;
+    let mut times = TimeMap::default();
+    let mut lineno = 0;
 
-  stream.lines().for_each(|line| {
-    if opts.verbose {
-      lineno += 1;
-      if lineno % 100_000 == 0 {
-        print!(".");
-        stdout().flush().unwrap();
-      }
-    }
-
-    match line {
-      Ok(l) => {
-        count_line(&mut times, l);
-      }
-      Err(e) => {
+    stream.lines().for_each(|line| {
         if opts.verbose {
-          eprintln!("Failed to read line:\n  {}", e);
+            lineno += 1;
+            if lineno % 100_000 == 0 {
+                print!(".");
+                stdout().flush().unwrap();
+            }
         }
-      }
+
+        match line {
+            Ok(l) => {
+                count_line(&mut times, l);
+            }
+            Err(e) => {
+                if opts.verbose {
+                    eprintln!("Failed to read line:\n  {}", e);
+                }
+            }
+        }
+    });
+
+    if opts.verbose {
+        println!();
     }
-  });
 
-  if opts.verbose {
-    println!();
-  }
-
-  times
+    times
 }
 
 #[inline]
 pub fn file_stats(path: &str, opts: &Options) -> TimeMap {
-  let file_stream = file::reader(path, opts);
-  stream_stats(file_stream, opts)
+    let file_stream = file::reader(path, opts);
+    stream_stats(file_stream, opts)
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,48 +1,48 @@
 use std::borrow::Cow;
 
 fn default_ip<'a>() -> Cow<'a, str> {
-  Cow::from("0.0.0.0")
+    Cow::from("0.0.0.0")
 }
 
 #[derive(Deserialize, Debug)]
 pub struct Request<'a> {
-  #[serde(borrow)]
-  pub timestamp: Cow<'a, str>,
-  // time_elapsed: u8,
-  #[serde(borrow)]
-  #[serde(default="default_ip")]
-  pub client_ip: Cow<'a, str>,
-  // client_continent: String,
-  // client_country: String,
-  // client_region: String,
-  // client_city: String,
-  // client_latitude: String,
-  // client_longitude: String,
-  // pub client_timezone: String,
-  // client_connection: String,
-  // request: String,
-  // request_host: String,
-  #[serde(borrow)]
-  pub request_path: Cow<'a, str>,
-  #[serde(borrow)]
-  pub request_query: Cow<'a, str>,
-  // request_bytes: u16,
-  #[serde(borrow)]
-  pub user_agent: Cow<'a, str>,
-  // pub http2: bool,
-  // pub tls: Option<bool>,
-  // #[serde(borrow)]
-  // pub tls_version: Cow<'a, str>,
-  #[serde(borrow)]
-  pub tls_cipher: Cow<'a, str>,
-  // response_status: String,
-  // response_text: String,
-  // response_bytes: u16,
-  // response_cache: String,
-  // cache_state: String,
-  // cache_lastuse: f32,
-  // cache_hits: u16,
-  // #[serde(borrow)]
-  // pub server_region: Cow<'a, str>,
-  // server_datacenter: String,
+    #[serde(borrow)]
+    pub timestamp: Cow<'a, str>,
+    // time_elapsed: u8,
+    #[serde(borrow)]
+    #[serde(default = "default_ip")]
+    pub client_ip: Cow<'a, str>,
+    // client_continent: String,
+    // client_country: String,
+    // client_region: String,
+    // client_city: String,
+    // client_latitude: String,
+    // client_longitude: String,
+    // pub client_timezone: String,
+    // client_connection: String,
+    // request: String,
+    // request_host: String,
+    #[serde(borrow)]
+    pub request_path: Cow<'a, str>,
+    #[serde(borrow)]
+    pub request_query: Cow<'a, str>,
+    // request_bytes: u16,
+    #[serde(borrow)]
+    pub user_agent: Cow<'a, str>,
+    // pub http2: bool,
+    // pub tls: Option<bool>,
+    // #[serde(borrow)]
+    // pub tls_version: Cow<'a, str>,
+    #[serde(borrow)]
+    pub tls_cipher: Cow<'a, str>,
+    // response_status: String,
+    // response_text: String,
+    // response_bytes: u16,
+    // response_cache: String,
+    // cache_state: String,
+    // cache_lastuse: f32,
+    // cache_hits: u16,
+    // #[serde(borrow)]
+    // pub server_region: Cow<'a, str>,
+    // server_datacenter: String,
 }

--- a/src/user_agent.rs
+++ b/src/user_agent.rs
@@ -2,196 +2,198 @@ use regex::Regex;
 
 #[derive(PartialEq, Debug)]
 pub struct UserAgent<'a> {
-  pub bundler: Option<&'a str>,
-  pub rubygems: &'a str,
-  pub ruby: Option<&'a str>,
-  pub platform: Option<&'a str>,
-  pub command: Option<&'a str>,
-  pub options: Option<&'a str>,
-  pub jruby: Option<&'a str>,
-  pub truffleruby: Option<&'a str>,
-  pub ci: Option<&'a str>,
-  pub gemstash: Option<&'a str>,
+    pub bundler: Option<&'a str>,
+    pub rubygems: &'a str,
+    pub ruby: Option<&'a str>,
+    pub platform: Option<&'a str>,
+    pub command: Option<&'a str>,
+    pub options: Option<&'a str>,
+    pub jruby: Option<&'a str>,
+    pub truffleruby: Option<&'a str>,
+    pub ci: Option<&'a str>,
+    pub gemstash: Option<&'a str>,
 }
 
 pub fn parse(a: &str) -> Option<UserAgent> {
-  lazy_static! {
-    // Here is the named regex. The regex created below does not include names, because that interface has borrowing issues 😬
-    // \Abundler/(?<bundler>[0-9a-zA-Z.\-]+) rubygems/(?<rubygems>[0-9a-zA-Z.\-]+) ruby/(?<ruby>[0-9a-zA-Z.\-]+) \((?<platform>.*)\) command/(.*?)(?: jruby/(?<jruby>[0-9a-zA-Z.\-]+))?(?: truffleruby/(?<truffleruby>[0-9a-zA-Z.\-]+))?(?: options/(?<options>.*?))?(?: ci/(?<ci>.*?))? ([a-f0-9]{16})(?: Gemstash/(?<gemstash>[0-9a-zA-Z.\-]+))?\z
-    static ref BUNDLER_PATTERN: Regex = Regex::new(r"\Abundler/([0-9a-zA-Z.\-]+) rubygems/([0-9a-zA-Z.\-]+) ruby/([0-9a-zA-Z.\-]+) \(([^)]*)\) command/(.*?)(?: jruby/([0-9a-zA-Z.\-]+))?(?: truffleruby/([0-9a-zA-Z.\-]+))?(?: options/(.*?))?(?: ci/(.*?))? [a-f0-9]{16}(?: Gemstash/([0-9a-zA-Z.\-]+))?\z").unwrap();
-    static ref RUBY_PATTERN: Regex = Regex::new(r"\A(?:Ruby, )?RubyGems/([0-9a-z.\-]+) (.*) Ruby/([0-9a-z.\-]+) \(.*?\)(?: jruby| truffleruby| rbx)?(?: Gemstash/([0-9a-z.\-]+))?\z").unwrap();
-    static ref GEM_PATTERN: Regex = Regex::new(r"\ARuby, Gems ([0-9a-z.\-]+)\z").unwrap();
-  }
+    lazy_static! {
+      // Here is the named regex. The regex created below does not include names, because that interface has borrowing issues 😬
+      // \Abundler/(?<bundler>[0-9a-zA-Z.\-]+) rubygems/(?<rubygems>[0-9a-zA-Z.\-]+) ruby/(?<ruby>[0-9a-zA-Z.\-]+) \((?<platform>.*)\) command/(.*?)(?: jruby/(?<jruby>[0-9a-zA-Z.\-]+))?(?: truffleruby/(?<truffleruby>[0-9a-zA-Z.\-]+))?(?: options/(?<options>.*?))?(?: ci/(?<ci>.*?))? ([a-f0-9]{16})(?: Gemstash/(?<gemstash>[0-9a-zA-Z.\-]+))?\z
+      static ref BUNDLER_PATTERN: Regex = Regex::new(r"\Abundler/([0-9a-zA-Z.\-]+) rubygems/([0-9a-zA-Z.\-]+) ruby/([0-9a-zA-Z.\-]+) \(([^)]*)\) command/(.*?)(?: jruby/([0-9a-zA-Z.\-]+))?(?: truffleruby/([0-9a-zA-Z.\-]+))?(?: options/(.*?))?(?: ci/(.*?))? [a-f0-9]{16}(?: Gemstash/([0-9a-zA-Z.\-]+))?\z").unwrap();
+      static ref RUBY_PATTERN: Regex = Regex::new(r"\A(?:Ruby, )?RubyGems/([0-9a-z.\-]+) (.*) Ruby/([0-9a-z.\-]+) \(.*?\)(?: jruby| truffleruby| rbx)?(?: Gemstash/([0-9a-z.\-]+))?\z").unwrap();
+      static ref GEM_PATTERN: Regex = Regex::new(r"\ARuby, Gems ([0-9a-z.\-]+)\z").unwrap();
+    }
 
-  let mut bl = BUNDLER_PATTERN.capture_locations();
-  let mut rl = RUBY_PATTERN.capture_locations();
-  let mut gl = GEM_PATTERN.capture_locations();
+    let mut bl = BUNDLER_PATTERN.capture_locations();
+    let mut rl = RUBY_PATTERN.capture_locations();
+    let mut gl = GEM_PATTERN.capture_locations();
 
-  if BUNDLER_PATTERN.captures_read(&mut bl, a).is_some() {
-    Some(UserAgent {
-      bundler: match bl.get(1) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      rubygems: match bl.get(2) {
-        Some(loc) => &a[loc.0..loc.1],
-        _ => panic!("parse failed on {:?}", a),
-      },
-      ruby: match bl.get(3) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      platform: match bl.get(4) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      command: match bl.get(5) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      jruby: match bl.get(6) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      truffleruby: match bl.get(7) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      options: match bl.get(8) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      ci: match bl.get(9) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      gemstash: match bl.get(11) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-    })
-  } else if RUBY_PATTERN.captures_read(&mut rl, a).is_some() {
-    return Some(UserAgent {
-      bundler: None,
-      rubygems: match rl.get(1) {
-        Some(loc) => &a[loc.0..loc.1],
-        _ => panic!("parse failed on {:?}", a),
-      },
-      ruby: match rl.get(3) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      platform: match rl.get(2) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      command: None,
-      jruby: None,
-      truffleruby: None,
-      options: None,
-      ci: None,
-      gemstash: match rl.get(4) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-    });
-  } else if GEM_PATTERN.captures_read(&mut gl, a).is_some() {
-    return Some(UserAgent {
-      bundler: None,
-      rubygems: match gl.get(1) {
-        Some(loc) => &a[loc.0..loc.1],
-        _ => panic!("parse failed on {:?}", a),
-      },
-      ruby: None,
-      platform: None,
-      command: None,
-      jruby: None,
-      truffleruby: None,
-      options: None,
-      ci: None,
-      gemstash: None,
-    });
-  } else {
-    return None;
-  }
+    if BUNDLER_PATTERN.captures_read(&mut bl, a).is_some() {
+        Some(UserAgent {
+            bundler: match bl.get(1) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+            rubygems: match bl.get(2) {
+                Some(loc) => &a[loc.0..loc.1],
+                _ => panic!("parse failed on {:?}", a),
+            },
+            ruby: match bl.get(3) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+            platform: match bl.get(4) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+            command: match bl.get(5) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+            jruby: match bl.get(6) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+            truffleruby: match bl.get(7) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+            options: match bl.get(8) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+            ci: match bl.get(9) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+            gemstash: match bl.get(11) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+        })
+    } else if RUBY_PATTERN.captures_read(&mut rl, a).is_some() {
+        return Some(UserAgent {
+            bundler: None,
+            rubygems: match rl.get(1) {
+                Some(loc) => &a[loc.0..loc.1],
+                _ => panic!("parse failed on {:?}", a),
+            },
+            ruby: match rl.get(3) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+            platform: match rl.get(2) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+            command: None,
+            jruby: None,
+            truffleruby: None,
+            options: None,
+            ci: None,
+            gemstash: match rl.get(4) {
+                Some(loc) => Some(&a[loc.0..loc.1]),
+                _ => None,
+            },
+        });
+    } else if GEM_PATTERN.captures_read(&mut gl, a).is_some() {
+        return Some(UserAgent {
+            bundler: None,
+            rubygems: match gl.get(1) {
+                Some(loc) => &a[loc.0..loc.1],
+                _ => panic!("parse failed on {:?}", a),
+            },
+            ruby: None,
+            platform: None,
+            command: None,
+            jruby: None,
+            truffleruby: None,
+            options: None,
+            ci: None,
+            gemstash: None,
+        });
+    } else {
+        return None;
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  extern crate test;
+    extern crate test;
 
-  use super::*;
-  use crate::file;
-  use std::io::BufRead;
-  use test::Bencher;
-  use crate::user_agent::UserAgent;
+    use super::*;
+    use crate::file;
+    use crate::user_agent::UserAgent;
+    use std::io::BufRead;
+    use test::Bencher;
 
-  #[test]
-  fn test_parse() {
-    assert_eq!(
-      parse("bundler/1.12.5 rubygems/2.6.10 ruby/2.3.1 (x86_64-pc-linux-gnu) command/install options/orig_path 95ac718b0e500f41"),
-      Some(UserAgent {
-        bundler: Some("1.12.5"),
-        rubygems: "2.6.10",
-        ruby: Some("2.3.1"),
-        platform: Some("x86_64-pc-linux-gnu"),
-        command: Some("install"),
-        options: Some("orig_path"),
-        jruby: None,
-        truffleruby: None,
-        ci: None,
-        gemstash: None,
-      })
-    );
+    #[test]
+    fn test_parse() {
+        assert_eq!(
+            parse(
+                "bundler/1.12.5 rubygems/2.6.10 ruby/2.3.1 (x86_64-pc-linux-gnu) command/install options/orig_path 95ac718b0e500f41"
+            ),
+            Some(UserAgent {
+                bundler: Some("1.12.5"),
+                rubygems: "2.6.10",
+                ruby: Some("2.3.1"),
+                platform: Some("x86_64-pc-linux-gnu"),
+                command: Some("install"),
+                options: Some("orig_path"),
+                jruby: None,
+                truffleruby: None,
+                ci: None,
+                gemstash: None,
+            })
+        );
 
-    assert_eq!(
-      parse("Ruby, RubyGems/2.4.8 x86_64-linux Ruby/2.1.6 (2015-04-13 patchlevel 336)"),
-      Some(UserAgent {
-        bundler: None,
-        rubygems: "2.4.8",
-        ruby: Some("2.1.6"),
-        platform: Some("x86_64-linux"),
-        command: None,
-        options: None,
-        jruby: None,
-        truffleruby: None,
-        ci: None,
-        gemstash: None,
-      })
-    );
+        assert_eq!(
+            parse("Ruby, RubyGems/2.4.8 x86_64-linux Ruby/2.1.6 (2015-04-13 patchlevel 336)"),
+            Some(UserAgent {
+                bundler: None,
+                rubygems: "2.4.8",
+                ruby: Some("2.1.6"),
+                platform: Some("x86_64-linux"),
+                command: None,
+                options: None,
+                jruby: None,
+                truffleruby: None,
+                ci: None,
+                gemstash: None,
+            })
+        );
 
-    assert_eq!(
-      parse("Ruby, Gems 1.1.1"),
-      Some(UserAgent {
-        bundler: None,
-        rubygems: "1.1.1",
-        ruby: None,
-        platform: None,
-        command: None,
-        options: None,
-        jruby: None,
-        truffleruby: None,
-        ci: None,
-        gemstash: None,
-      })
-    );
+        assert_eq!(
+            parse("Ruby, Gems 1.1.1"),
+            Some(UserAgent {
+                bundler: None,
+                rubygems: "1.1.1",
+                ruby: None,
+                platform: None,
+                command: None,
+                options: None,
+                jruby: None,
+                truffleruby: None,
+                ci: None,
+                gemstash: None,
+            })
+        );
 
-    use crate::Options;
-    let opts = Options {
-      paths: vec![],
-      verbose: false,
-      unknown: false,
-    };
-    let file = file::reader("test/client_user_agents.txt", &opts);
-    for line in file.lines() {
-      let input = &line.unwrap();
-      parse(input).unwrap_or_else(|| panic!("couldn't parse {:?}", input));
+        use crate::Options;
+        let opts = Options {
+            paths: vec![],
+            verbose: false,
+            unknown: false,
+        };
+        let file = file::reader("test/client_user_agents.txt", &opts);
+        for line in file.lines() {
+            let input = &line.unwrap();
+            parse(input).unwrap_or_else(|| panic!("couldn't parse {:?}", input));
+        }
     }
-  }
 
-  #[bench]
-  fn bench_parse(b: &mut Bencher) {
-    b.iter(|| {
+    #[bench]
+    fn bench_parse(b: &mut Bencher) {
+        b.iter(|| {
       parse("bundler/1.16.1 rubygems/2.6.11 ruby/2.4.1 (x86_64-pc-linux-gnu) command/install options/no_install,mirror.https://rubygems.org/,mirror.https://rubygems.org/.fallback_timeout/,path 59dbf8e99fa09c0a");
       parse("bundler/1.12.5 rubygems/2.6.10 ruby/2.3.1 (x86_64-pc-linux-gnu) command/install options/orig_path 95ac718b0e500f41");
       parse("bundler/1.16.1 rubygems/2.7.6 ruby/2.5.1 (x86_64-pc-linux-gnu) command/install rbx/3.105 options/no_install,git.allow_insecure,build.nokogiri,jobs,path,app_config,silence_root_warning,bin,gemfile e710485d04febb1e");
@@ -203,5 +205,5 @@ mod tests {
       parse("Ruby, RubyGems/1.3.7 x86_64-linux Ruby/1.9.2 (2010-08-18 patchlevel 0)");
       parse("Ruby, RubyGems/2.6.6 x86_64-linux Ruby/2.3.1 (2018-01-06 patchlevel 0) rbx");
     })
-  }
+    }
 }


### PR DESCRIPTION
Now the code is standard-formatted, and lsp format on save will not produce extraneous diffs