### PR TITLE
avoid contending on single process-wide precompiled regexes

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -17,8 +17,8 @@ pub fn reader(filename: &str, opts: &super::Options) -> Box<dyn BufRead> {
   };
 
   if path.extension() == Some(OsStr::new("gz")) {
-    Box::new(BufReader::with_capacity(128 * 1024, GzDecoder::new(file)))
+    Box::new(BufReader::with_capacity(1024 * 1024, GzDecoder::new(file)))
   } else {
-    Box::new(BufReader::with_capacity(128 * 1024, file))
+    Box::new(BufReader::with_capacity(1024 * 1024, file))
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![feature(test)]
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate enum_map;
@@ -126,14 +124,15 @@ fn increment_maybe(counters: &mut NameMap, name: FieldName, maybe_value: Option<
 }
 
 pub fn print_unknown_user_agents(path: &str, opts: &Options) {
+    let ctx = user_agent::ParseCtx::new();
   file::reader(path, opts).split(b'\n').for_each(|line| {
     let l = &line.unwrap();
     let r: request::Request = serde_json::from_slice(l).unwrap();
-    if user_agent::parse(r.user_agent.as_ref()).is_none() { println!("{}", r.user_agent) }
+    if ctx.parse(r.user_agent.as_ref()).is_none() { println!("{}", r.user_agent) }
   });
 }
 
-pub fn count_line(times: &mut TimeMap, line: String) {
+pub fn count_line(ctx: &user_agent::ParseCtx, times: &mut TimeMap, line: String) {
   let r: request::Request = serde_json::from_str(&line).unwrap();
 
   if duplicate_request(&r) {
@@ -148,7 +147,7 @@ pub fn count_line(times: &mut TimeMap, line: String) {
   let user_key = r.client_ip.parse().expect("ipaddr parse error");
 
   increment(counters, FieldName::tls_cipher, r.tls_cipher.as_ref(), user_key);
-  if let Some(ua) = user_agent::parse(r.user_agent.as_ref()) {
+  if let Some(ua) = ctx.parse(r.user_agent.as_ref()) {
     increment(counters, FieldName::rubygems, ua.rubygems, user_key);
     increment_maybe(counters, FieldName::bundler, ua.bundler, user_key);
     increment_maybe(counters, FieldName::ruby, ua.ruby, user_key);
@@ -162,6 +161,8 @@ pub fn stream_stats(stream: Box<dyn BufRead>, opts: &Options) -> TimeMap {
   let mut times = TimeMap::default();
   let mut lineno = 0;
 
+  let ctx = user_agent::ParseCtx::new();
+
   stream.lines().for_each(|line| {
     if opts.verbose {
       lineno += 1;
@@ -173,7 +174,7 @@ pub fn stream_stats(stream: Box<dyn BufRead>, opts: &Options) -> TimeMap {
 
     match line {
       Ok(l) => {
-        count_line(&mut times, l);
+        count_line(&ctx, &mut times, l);
       }
       Err(e) => {
         if opts.verbose {

--- a/src/user_agent.rs
+++ b/src/user_agent.rs
@@ -14,105 +14,122 @@ pub struct UserAgent<'a> {
   pub gemstash: Option<&'a str>,
 }
 
-pub fn parse(a: &str) -> Option<UserAgent> {
+pub struct ParseCtx {
+  bundler_pattern: Regex,
+  ruby_pattern: Regex,
+  gem_pattern: Regex,
+}
+
+impl ParseCtx {
+  /*
+   * Here are some more regexes that indirect commented out so they didn't get moved to ParseCtx.
+   * have fun :)
+   */
+  /*
   lazy_static! {
     // Here is the named regex. The regex created below does not include names, because that interface has borrowing issues 😬
     // \Abundler/(?<bundler>[0-9a-zA-Z.\-]+) rubygems/(?<rubygems>[0-9a-zA-Z.\-]+) ruby/(?<ruby>[0-9a-zA-Z.\-]+) \((?<platform>.*)\) command/(.*?)(?: jruby/(?<jruby>[0-9a-zA-Z.\-]+))?(?: truffleruby/(?<truffleruby>[0-9a-zA-Z.\-]+))?(?: options/(?<options>.*?))?(?: ci/(?<ci>.*?))? ([a-f0-9]{16})(?: Gemstash/(?<gemstash>[0-9a-zA-Z.\-]+))?\z
-    static ref BUNDLER_PATTERN: Regex = Regex::new(r"\Abundler/([0-9a-zA-Z.\-]+) rubygems/([0-9a-zA-Z.\-]+) ruby/([0-9a-zA-Z.\-]+) \(([^)]*)\) command/(.*?)(?: jruby/([0-9a-zA-Z.\-]+))?(?: truffleruby/([0-9a-zA-Z.\-]+))?(?: options/(.*?))?(?: ci/(.*?))? [a-f0-9]{16}(?: Gemstash/([0-9a-zA-Z.\-]+))?\z").unwrap();
-    static ref RUBY_PATTERN: Regex = Regex::new(r"\A(?:Ruby, )?RubyGems/([0-9a-z.\-]+) (.*) Ruby/([0-9a-z.\-]+) \(.*?\)(?: jruby| truffleruby| rbx)?(?: Gemstash/([0-9a-z.\-]+))?\z").unwrap();
-    static ref GEM_PATTERN: Regex = Regex::new(r"\ARuby, Gems ([0-9a-z.\-]+)\z").unwrap();
+  }
+  */
+  pub fn new() -> Self {
+    Self {
+      bundler_pattern: Regex::new(r"\Abundler/([0-9a-zA-Z.\-]+) rubygems/([0-9a-zA-Z.\-]+) ruby/([0-9a-zA-Z.\-]+) \(([^)]*)\) command/(.*?)(?: jruby/([0-9a-zA-Z.\-]+))?(?: truffleruby/([0-9a-zA-Z.\-]+))?(?: options/(.*?))?(?: ci/(.*?))? [a-f0-9]{16}(?: Gemstash/([0-9a-zA-Z.\-]+))?\z").unwrap(),
+      ruby_pattern: Regex::new(r"\A(?:Ruby, )?RubyGems/([0-9a-z.\-]+) (.*) Ruby/([0-9a-z.\-]+) \(.*?\)(?: jruby| truffleruby| rbx)?(?: Gemstash/([0-9a-z.\-]+))?\z").unwrap(),
+      gem_pattern: Regex::new(r"\ARuby, Gems ([0-9a-z.\-]+)\z").unwrap(),
+    }
   }
 
-  let mut bl = BUNDLER_PATTERN.capture_locations();
-  let mut rl = RUBY_PATTERN.capture_locations();
-  let mut gl = GEM_PATTERN.capture_locations();
-
-  if BUNDLER_PATTERN.captures_read(&mut bl, a).is_some() {
-    Some(UserAgent {
-      bundler: match bl.get(1) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      rubygems: match bl.get(2) {
-        Some(loc) => &a[loc.0..loc.1],
-        _ => panic!("parse failed on {:?}", a),
-      },
-      ruby: match bl.get(3) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      platform: match bl.get(4) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      command: match bl.get(5) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      jruby: match bl.get(6) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      truffleruby: match bl.get(7) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      options: match bl.get(8) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      ci: match bl.get(9) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      gemstash: match bl.get(11) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-    })
-  } else if RUBY_PATTERN.captures_read(&mut rl, a).is_some() {
-    return Some(UserAgent {
-      bundler: None,
-      rubygems: match rl.get(1) {
-        Some(loc) => &a[loc.0..loc.1],
-        _ => panic!("parse failed on {:?}", a),
-      },
-      ruby: match rl.get(3) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      platform: match rl.get(2) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-      command: None,
-      jruby: None,
-      truffleruby: None,
-      options: None,
-      ci: None,
-      gemstash: match rl.get(4) {
-        Some(loc) => Some(&a[loc.0..loc.1]),
-        _ => None,
-      },
-    });
-  } else if GEM_PATTERN.captures_read(&mut gl, a).is_some() {
-    return Some(UserAgent {
-      bundler: None,
-      rubygems: match gl.get(1) {
-        Some(loc) => &a[loc.0..loc.1],
-        _ => panic!("parse failed on {:?}", a),
-      },
-      ruby: None,
-      platform: None,
-      command: None,
-      jruby: None,
-      truffleruby: None,
-      options: None,
-      ci: None,
-      gemstash: None,
-    });
-  } else {
-    return None;
+  pub fn parse<'line>(&self, a: &'line str) -> Option<UserAgent<'line>> {
+    let mut bl = self.bundler_pattern.capture_locations();
+    let mut rl = self.ruby_pattern.capture_locations();
+    let mut gl = self.gem_pattern.capture_locations();
+    if self.bundler_pattern.captures_read(&mut bl, a).is_some() {
+      Some(UserAgent {
+        bundler: match bl.get(1) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+        rubygems: match bl.get(2) {
+          Some(loc) => &a[loc.0..loc.1],
+          _ => panic!("parse failed on {:?}", a),
+        },
+        ruby: match bl.get(3) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+        platform: match bl.get(4) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+        command: match bl.get(5) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+        jruby: match bl.get(6) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+        truffleruby: match bl.get(7) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+        options: match bl.get(8) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+        ci: match bl.get(9) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+        gemstash: match bl.get(11) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+      })
+    } else if self.ruby_pattern.captures_read(&mut rl, a).is_some() {
+      return Some(UserAgent {
+        bundler: None,
+        rubygems: match rl.get(1) {
+          Some(loc) => &a[loc.0..loc.1],
+          _ => panic!("parse failed on {:?}", a),
+        },
+        ruby: match rl.get(3) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+        platform: match rl.get(2) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+        command: None,
+        jruby: None,
+        truffleruby: None,
+        options: None,
+        ci: None,
+        gemstash: match rl.get(4) {
+          Some(loc) => Some(&a[loc.0..loc.1]),
+          _ => None,
+        },
+      });
+    } else if self.gem_pattern.captures_read(&mut gl, a).is_some() {
+      return Some(UserAgent {
+        bundler: None,
+        rubygems: match gl.get(1) {
+          Some(loc) => &a[loc.0..loc.1],
+          _ => panic!("parse failed on {:?}", a),
+        },
+        ruby: None,
+        platform: None,
+        command: None,
+        jruby: None,
+        truffleruby: None,
+        options: None,
+        ci: None,
+        gemstash: None,
+      });
+    } else {
+      return None;
+    }
   }
 }
 
@@ -128,8 +145,9 @@ mod tests {
 
   #[test]
   fn test_parse() {
+    let ctx = ParseCtx::new();
     assert_eq!(
-      parse("bundler/1.12.5 rubygems/2.6.10 ruby/2.3.1 (x86_64-pc-linux-gnu) command/install options/orig_path 95ac718b0e500f41"),
+      ctx.parse("bundler/1.12.5 rubygems/2.6.10 ruby/2.3.1 (x86_64-pc-linux-gnu) command/install options/orig_path 95ac718b0e500f41"),
       Some(UserAgent {
         bundler: Some("1.12.5"),
         rubygems: "2.6.10",
@@ -145,7 +163,7 @@ mod tests {
     );
 
     assert_eq!(
-      parse("Ruby, RubyGems/2.4.8 x86_64-linux Ruby/2.1.6 (2015-04-13 patchlevel 336)"),
+      ctx.parse("Ruby, RubyGems/2.4.8 x86_64-linux Ruby/2.1.6 (2015-04-13 patchlevel 336)"),
       Some(UserAgent {
         bundler: None,
         rubygems: "2.4.8",
@@ -161,7 +179,7 @@ mod tests {
     );
 
     assert_eq!(
-      parse("Ruby, Gems 1.1.1"),
+      ctx.parse("Ruby, Gems 1.1.1"),
       Some(UserAgent {
         bundler: None,
         rubygems: "1.1.1",
@@ -185,23 +203,24 @@ mod tests {
     let file = file::reader("test/client_user_agents.txt", &opts);
     for line in file.lines() {
       let input = &line.unwrap();
-      parse(input).unwrap_or_else(|| panic!("couldn't parse {:?}", input));
+      ctx.parse(input).unwrap_or_else(|| panic!("couldn't parse {:?}", input));
     }
   }
 
   #[bench]
   fn bench_parse(b: &mut Bencher) {
+    let ctx = ParseCtx::new();
     b.iter(|| {
-      parse("bundler/1.16.1 rubygems/2.6.11 ruby/2.4.1 (x86_64-pc-linux-gnu) command/install options/no_install,mirror.https://rubygems.org/,mirror.https://rubygems.org/.fallback_timeout/,path 59dbf8e99fa09c0a");
-      parse("bundler/1.12.5 rubygems/2.6.10 ruby/2.3.1 (x86_64-pc-linux-gnu) command/install options/orig_path 95ac718b0e500f41");
-      parse("bundler/1.16.1 rubygems/2.7.6 ruby/2.5.1 (x86_64-pc-linux-gnu) command/install rbx/3.105 options/no_install,git.allow_insecure,build.nokogiri,jobs,path,app_config,silence_root_warning,bin,gemfile e710485d04febb1e");
-      parse("bundler/1.12.5 rubygems/2.6.10 ruby/2.3.1 (x86_64-pc-linux-gnu) command/install options/orig_path 95ac718b0e500f41");
-      parse("bundler/1.15.4 rubygems/2.6.14 ruby/2.4.2 (x86_64-w64-mingw32) command/install options/ 6e8fa23dbf26d4ff Gemstash/1.1.0");
-      parse("bundler/1.16.2 rubygems/2.7.6 ruby/2.5.0 (x86_64-Oracle Corporation-linux) command/install jruby/9.2.1.0-SNAPSHOT options/no_install,retry,jobs,gemfile ci/travis,ci fe5e45257d515f1f");
-      parse("bundler/1.5.1 rubygems/2.2.0 ruby/2.1.0 (x86_64-unknown-linux-gnu) command/install fe5e45257d515f1f");
-      parse("Ruby, Gems 1.1.1");
-      parse("Ruby, RubyGems/1.3.7 x86_64-linux Ruby/1.9.2 (2010-08-18 patchlevel 0)");
-      parse("Ruby, RubyGems/2.6.6 x86_64-linux Ruby/2.3.1 (2018-01-06 patchlevel 0) rbx");
+      ctx.parse("bundler/1.16.1 rubygems/2.6.11 ruby/2.4.1 (x86_64-pc-linux-gnu) command/install options/no_install,mirror.https://rubygems.org/,mirror.https://rubygems.org/.fallback_timeout/,path 59dbf8e99fa09c0a");
+      ctx.parse("bundler/1.12.5 rubygems/2.6.10 ruby/2.3.1 (x86_64-pc-linux-gnu) command/install options/orig_path 95ac718b0e500f41");
+      ctx.parse("bundler/1.16.1 rubygems/2.7.6 ruby/2.5.1 (x86_64-pc-linux-gnu) command/install rbx/3.105 options/no_install,git.allow_insecure,build.nokogiri,jobs,path,app_config,silence_root_warning,bin,gemfile e710485d04febb1e");
+      ctx.parse("bundler/1.12.5 rubygems/2.6.10 ruby/2.3.1 (x86_64-pc-linux-gnu) command/install options/orig_path 95ac718b0e500f41");
+      ctx.parse("bundler/1.15.4 rubygems/2.6.14 ruby/2.4.2 (x86_64-w64-mingw32) command/install options/ 6e8fa23dbf26d4ff Gemstash/1.1.0");
+      ctx.parse("bundler/1.16.2 rubygems/2.7.6 ruby/2.5.0 (x86_64-Oracle Corporation-linux) command/install jruby/9.2.1.0-SNAPSHOT options/no_install,retry,jobs,gemfile ci/travis,ci fe5e45257d515f1f");
+      ctx.parse("bundler/1.5.1 rubygems/2.2.0 ruby/2.1.0 (x86_64-unknown-linux-gnu) command/install fe5e45257d515f1f");
+      ctx.parse("Ruby, Gems 1.1.1");
+      ctx.parse("Ruby, RubyGems/1.3.7 x86_64-linux Ruby/1.9.2 (2010-08-18 patchlevel 0)");
+      ctx.parse("Ruby, RubyGems/2.6.6 x86_64-linux Ruby/2.3.1 (2018-01-06 patchlevel 0) rbx");
     })
   }
 }


### PR DESCRIPTION
precompiling the `Regex` instances is good! but being behind
`lazy_static!` means all threads are contending an implicit futex
somewhere in the lazy_static implementation. on a 32-core system with 32
logs to process in parallel, this ends up with the top symbol in
`perf stat` to be something in `futex` and an awful lot of total time
waiting on _system stuff_ for no apparent reason.

having set of Regex bundles per-thread keeps contention down at the
cost of a bit more init on the multi-processor case, but overall at
least on my system brings a 31-file benchmark down from 4.6 seconds to
about 2.2 seconds.

i included a bonus second change to make the read buffers a bit larger but that's not nearly as useful