### PR TITLE
Pass --no-cli-pager when deploying

### DIFF
--- a/bin/deploy-lambda
+++ b/bin/deploy-lambda
@@ -14,9 +14,11 @@ rm bootstrap
 cd -
 
 aws lambda update-function-code \
+  --no-cli-pager \
   --function-name "kirby-s3" \
   --zip-file "fileb://target/x86_64-unknown-linux-musl/release/aws_lambda.zip"
 aws lambda update-function-code \
+  --no-cli-pager \
   --function-name "kirby-s3-clickhouse" \
   --zip-file "fileb://target/x86_64-unknown-linux-musl/release/aws_lambda_clickhouse.zip"
 set +x


### PR DESCRIPTION
So the second deploy doesnt accidentally get blocked by the terminal pager waiting to exit

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
