### PR TITLE
Gracefully handle 304s in clickhouse stream

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -15,6 +15,10 @@ impl ResponseStatus {
     pub fn is_success(&self) -> bool {
         self.0 == 200 || self.0 == 304
     }
+
+    pub fn not_modified(&self) -> bool {
+        self.0 == 304
+    }
 }
 
 impl<'de> Deserialize<'de> for ResponseStatus {


### PR DESCRIPTION
304s do not contain the headers, but are a very small percentage of traffic

Dropping them instead of erroring unblocks the rest of the requests making their way into clickhouse

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
